### PR TITLE
WIP, Example: using intersphinx to link w/ nx docs.

### DIFF
--- a/content/generators/geometric.md
+++ b/content/generators/geometric.md
@@ -24,8 +24,8 @@ language_info:
 
 # Tutorial: Geometric Generator Models
 
-In this tutorial, we'll explore the geometric network generator models
-implemented in networkx under networkx/generators/geometric.py and apply them
+In this tutorial, we'll explore the
+{mod}`geometric network generator <networkx.generators.geometric>` models and apply them
 to a real-world use case to learn how these models can be parameterized and used.
 
 ## Geometric/Spatial Networks
@@ -193,7 +193,6 @@ We will define a helper function called `draw_edges_fast` to use instead of the
 usual `draw_networkx_edges`, as some of the geometric graphs examined below have
 more than 10,000 edges.
 
-
 ```{code-cell} ipython3
 from matplotlib.collections import LineCollection
 
@@ -215,11 +214,9 @@ def draw_edges_fast(G, pos, ax, **lc_kwargs):
     edge_pos = np.array([(pos[e[0]], pos[e[1]]) for e in RGG.edges()])
     edge_collection = LineCollection(edge_pos, **lc_kwargs)
     ax.add_collection(edge_collection)
-
 ```
 
 Next, we load the data and construct the graph.
-
 
 ```{code-cell} ipython3
 ---

--- a/site/conf.py
+++ b/site/conf.py
@@ -29,7 +29,12 @@ author = 'NetworkX developers'
 # ones.
 extensions = [
     "myst_nb",
+    "sphinx.ext.intersphinx",
 ]
+
+intersphinx_mapping = {
+    "networkx": ("https://networkx.org/documentation/stable", None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
A single example of using MyST markdown features to setup intersphinx for the notebooks site.

The main advantage is that we can use roles+directives+sphinx extensions for the notebooks!

The main disadvantage is that the extended (i.e. non-commonmark) MyST features are not yet supported in Jupyter notebooks. So for users who are using binder and/or running notebooks locally w/ `jupyter notebook`, the markup will not render properly. 