### PR TITLE
Setup site deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,49 @@ jobs:
       - store_artifacts:
           path: site/_build/html
 
+      - persist_to_workspace:
+          root: site/_build
+          paths: html
+
+  deploy-docs:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/python:3.9.2
+
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: site/_build
+
+      - run:
+          name: Install deploy dependencies
+          command: python3 -m pip install --user ghp-import
+
+      - run:
+          name: Configure git
+          command: |
+            git config --global user.name "ci-doc-deploy-bot"
+            git config --global user.email "ci-doc-deploy-bot@nomail"
+            git config --global push.default simple
+
+      - add_ssh_keys:
+          fingerprints:
+            TODO!!!!!
+
+      - run:
+          name: Deploy via gh-pages
+          command: |
+            ghp-import -n -f -p -m "[skip ci] docs built of $CIRCLE_SHA1" site/_build/html
+
 workflows:
   version: 2
   build:
     jobs:
       - build-docs
+      - deploy-docs:
+        requires:
+          - build-docs
+        filters:
+          branches:
+            only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ workflows:
     jobs:
       - build-docs
       - deploy-docs:
-        requires:
-          - build-docs
-        filters:
-          branches:
-            only: main
+          requires:
+            - build-docs
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            TODO!!!!!
+            - c4:33:f8:20:13:b6:17:d0:40:0a:5e:be:59:3a:a9:31
 
       - run:
           name: Deploy via gh-pages

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# notebooks
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/networkx/notebooks/main)
+# nx-guides
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/networkx/nx-guides/main)
 
 Examples and IPython Notebooks about NetworkX
 

--- a/site/_templates/beta_banner.html
+++ b/site/_templates/beta_banner.html
@@ -1,0 +1,5 @@
+{# Create a banner at the top of the page warning users that the site is experimental #}
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+  <p>This site is currently experimental; the content and URLs may change or be removed!</p>
+</div>

--- a/site/_templates/layout.html
+++ b/site/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends "!layout.html" %}
+
+{% block docs_body %}
+    {% include "beta_banner.html" %}
+    {{ super() }}
+{% endblock %}

--- a/site/conf.py
+++ b/site/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'networkx-notebooks'
+project = 'nx-guides'
 copyright = '2021, NetworkX developers'
 author = 'NetworkX developers'
 
@@ -53,12 +53,12 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/networkx/notebooks/",
+            "url": "https://github.com/networkx/nx-guides/",
             "icon": "fab fa-github-square",
         },
         {
             "name": "Binder",
-            "url": "https://mybinder.org/v2/gh/networkx/notebooks/main?urlpath=lab/tree/content",
+            "url": "https://mybinder.org/v2/gh/networkx/nx-guides/main?urlpath=lab/tree/content",
             "icon": "fas fa-rocket",
         },
     ],
@@ -66,7 +66,7 @@ html_theme_options = {
 }
 html_context = {
     "github_user": "networkx",
-    "github_repo": "notebooks",
+    "github_repo": "nx-guides",
     "github_version": "main",
     "doc_path": "site",
 }

--- a/site/index.md
+++ b/site/index.md
@@ -1,9 +1,9 @@
-Welcome to NetworkX-notebooks
-=============================
+Welcome to nx-guides!
+=====================
 
 [![Binder](https://mybinder.org/badge_logo.svg)][launch_binder]
 
-[launch_binder]: https://mybinder.org/v2/gh/networkx/notebooks/main?urlpath=lab/tree/content
+[launch_binder]: https://mybinder.org/v2/gh/networkx/nx-guides/main?urlpath=lab/tree/content
 
 This site provides educational materials officially developed and curated by the
 NetworkX community.


### PR DESCRIPTION
 - Make necessary changes to reflect repo name change from `notebooks` -> `nx-guides`
 - Add warning banner to pages to notify anyone who lands on `networkx.org/nx-guides` that we're still in the setup phase
 - Add a deploy workflow to the circleci job