### PR TITLE
Pin pip to 21.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
           command: |
             python3 -m venv venv
             source venv/bin/activate
-            pip install --upgrade pip wheel setuptools
+            pip install --upgrade wheel setuptools
+            pip install pip==21.1.1
             pip install -r requirements.txt
 
       - run:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -37,7 +37,7 @@ jobs:
   
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
+        pip install pip==21.1.1
         pip install -r requirements.txt
     - name: Test with nbval
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 matplotlib
+scipy
 pygraphviz
 nbval
 git+git://github.com/networkx/networkx@main


### PR DESCRIPTION
There is a regression for our case in pip's dependency resolver in v21.2.1 - see pypa/pip#10201. This locks up our CI, so the temporary fix is to pin the pip version. ba4766f should be reverted once pip's dependency resolver is fixed.