### PR TITLE
Switch back to sphinx_book_theme.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ nbval
 git+git://github.com/networkx/networkx@main
 sphinx
 myst-nb
-pydata-sphinx-theme
+sphinx-book-theme
 jupytext

--- a/site/conf.py
+++ b/site/conf.py
@@ -45,30 +45,21 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pydata_sphinx_theme'
+html_theme = 'sphinx_book_theme'
 html_title = 'NetworkX Notebooks'
 html_logo = '_static/networkx_logo.svg'
 # html_favicon
 html_theme_options = {
-    "icon_links": [
-        {
-            "name": "GitHub",
-            "url": "https://github.com/networkx/nx-guides/",
-            "icon": "fab fa-github-square",
-        },
-        {
-            "name": "Binder",
-            "url": "https://mybinder.org/v2/gh/networkx/nx-guides/main?urlpath=lab/tree/content",
-            "icon": "fas fa-rocket",
-        },
-    ],
+    "github_url": "https://github.com/networkx/notebooks/",
+    "repository_url": "https://github.com/networkx/notebooks/",
+    "repository_branch": "main",
+    "use_repository_button": True,
+    "use_issues_button": True,
     "use_edit_page_button": True,
-}
-html_context = {
-    "github_user": "networkx",
-    "github_repo": "nx-guides",
-    "github_version": "main",
-    "doc_path": "site",
+    "path_to_docs": "site/",
+    "launch_buttons": {
+        "binderhub_url": "https://mybinder.org",
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/site/conf.py
+++ b/site/conf.py
@@ -50,8 +50,8 @@ html_title = 'NetworkX Notebooks'
 html_logo = '_static/networkx_logo.svg'
 # html_favicon
 html_theme_options = {
-    "github_url": "https://github.com/networkx/notebooks/",
-    "repository_url": "https://github.com/networkx/notebooks/",
+    "github_url": "https://github.com/networkx/nx-guides/",
+    "repository_url": "https://github.com/networkx/nx-guides/",
     "repository_branch": "main",
     "use_repository_button": True,
     "use_issues_button": True,


### PR DESCRIPTION
Essentially reverts #29 

The motivation for switching from `sphinx-book-theme` to `pydata-sphinx-theme` was that nx-guides was going to be accessible from the documentation, so it would make sense for it to have the same theme as the documentation. However, the sphinx-book-theme has a couple features that IMO are better for learning/interacting with the notebooks (e.g. launch buttons, a full-screen mode). Also, `nx-guides` is accessed from the [nav-bar in the main docs](https://networkx.org/documentation/latest/), which indicates that it's an external link so it shouldn't be *too* jarring for users that there is a change in the theme. Finally, the themes are derived from the same base so aren't *that* dissimilar, which should mitigate concerns about their differences.