### PR TITLE
Reorganize content and remove warning banner

### DIFF
--- a/content/algorithms/assortativity/correlation.md
+++ b/content/algorithms/assortativity/correlation.md
@@ -22,7 +22,7 @@ language_info:
   version: 3.8.5
 ---
 
-# Tutorial: Node assortativity coefficients and correlation measures
+# Node assortativity coefficients and correlation measures
 
 In this tutorial, we will go through the theory of [assortativity](https://en.wikipedia.org/wiki/Assortativity) and its measures.
 

--- a/content/algorithms/dag/index.md
+++ b/content/algorithms/dag/index.md
@@ -22,7 +22,7 @@ language_info:
   version: 3.9.2
 ---
 
-# Tutorial: Directed Acyclic Graphs
+# Directed Acyclic Graphs & Topological Sort
 
 In this tutorial, we will explore the algorithms related to a directed acyclic graph
 (or a "dag" as it is sometimes called) implemented in networkx under `networkx/algorithms/dag.py`.

--- a/content/algorithms/index.md
+++ b/content/algorithms/index.md
@@ -1,0 +1,12 @@
+# Algorithms
+
+A closer look at some of the algorithms and network analysis techniques
+provided by NetworkX.
+
+```{toctree}
+---
+maxdepth: 1
+---
+assortativity/correlation
+dag/index
+```

--- a/content/generators/geometric.md
+++ b/content/generators/geometric.md
@@ -22,7 +22,7 @@ language_info:
   version: 3.7.4
 ---
 
-# Tutorial: Geometric Generator Models
+# Geometric Generator Models
 
 In this tutorial, we'll explore the geometric network generator models
 implemented in networkx under networkx/generators/geometric.py and apply them

--- a/content/generators/index.md
+++ b/content/generators/index.md
@@ -1,0 +1,11 @@
+# Graph Generators
+
+A closer look at the functions provided by NetworkX to create interesting
+graphs.
+
+```{toctree}
+---
+maxdepth: 1
+---
+geometric
+```

--- a/site/_templates/beta_banner.html
+++ b/site/_templates/beta_banner.html
@@ -1,5 +1,0 @@
-{# Create a banner at the top of the page warning users that the site is experimental #}
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-  <p>This site is currently experimental; the content and URLs may change or be removed!</p>
-</div>

--- a/site/_templates/layout.html
+++ b/site/_templates/layout.html
@@ -1,6 +1,0 @@
-{% extends "!layout.html" %}
-
-{% block docs_body %}
-    {% include "beta_banner.html" %}
-    {{ super() }}
-{% endblock %}

--- a/site/index.md
+++ b/site/index.md
@@ -36,8 +36,7 @@ maxdepth: 1
 ---
 
 content/tutorial
-content/generators/geometric
-content/algorithms/assortativity/correlation
-content/algorithms/dag/index
+content/algorithms/index
+content/generators/index
 ```
 


### PR DESCRIPTION
Now that we have a few more excellent notebooks (thanks @vdshk & @harshal-dupare !) I think there is enough here to make the nx-guides site more "official". To do so, this PR:
 1. Removes the warning banner that was previously in all pages. There will no longer be a Warning that the site is in beta
 2. Adds a bit of hierarchical organization to the site.

This second point just tries to add some organization to make the navbar more useful. Instead of calling each notebook `Tutorial: ...`, I've removed the `Tutorial` part and categorized the notebooks into "Algorithms" and "Generators", which will be the new top-level categories that show up in the nav-bar on every page. The categories can be changed at any time, I just thought these made sense given the notebooks we currently have. Suggestions welcome!