### PR TITLE
CI: Test out nbqa for linting notebooks

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -39,8 +39,10 @@ jobs:
       run: |
         pip install pip==21.1.1
         pip install -r requirements.txt
+        pip install nbqa
     - name: Test with nbval
       run: |
         pip install pytest
         find content/ -name "*.md" -exec jupytext --to notebook {} \;
+        nbqa black .
         pytest --nbval-lax content/


### PR DESCRIPTION
We can use https://github.com/nbQA-dev/nbQA to lint and format our notebooks, it can run many linters like `black`, `isort`, `pyupgrade` and also format the markdown cells in the notebook.

https://github.com/networkx/nx-guides/issues/45

