### PR TITLE
Documentation for issue 53

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,152 @@
+.. _code_of_conduct:
+
+Code of Conduct
+===============
+
+
+Introduction
+------------
+
+This code of conduct applies to all spaces managed by the NetworkX project,
+including all public and private mailing lists, issue trackers, wikis, and
+any other communication channel used by our community.
+
+This code of conduct should be honored by everyone who participates in
+the NetworkX community formally or informally, or claims any affiliation with the
+project, in any project-related activities and especially when representing the
+project, in any role.
+
+This code is not exhaustive or complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. Please try to
+follow this code in spirit as much as in letter, to create a friendly and
+productive environment that enriches the surrounding community.
+
+
+Specific Guidelines
+-------------------
+
+We strive to:
+
+1. Be open. We invite anyone to participate in our community. We prefer to use
+   public methods of communication for project-related messages, unless
+   discussing something sensitive. This applies to messages for help or
+   project-related support, too; not only is a public support request much more
+   likely to result in an answer to a question, it also ensures that any
+   inadvertent mistakes in answering are more easily detected and corrected.
+
+2. Be empathetic, welcoming, friendly, and patient. We work together to resolve
+   conflict, and assume good intentions. We may all experience some frustration
+   from time to time, but we do not allow frustration to turn into a personal
+   attack. A community where people feel uncomfortable or threatened is not a
+   productive one.
+
+3. Be collaborative. Our work will be used by other people, and in turn we will
+   depend on the work of others. When we make something for the benefit of the
+   project, we are willing to explain to others how it works, so that they can
+   build on the work to make it even better. Any decision we make will affect
+   users and colleagues, and we take those consequences seriously when making
+   decisions.
+
+4. Be inquisitive. Nobody knows everything! Asking questions early avoids many
+   problems later, so we encourage questions, although we may direct them to
+   the appropriate forum. We will try hard to be responsive and helpful.
+
+5. Be careful in the words that we choose.  We are careful and respectful in
+   our communication and we take responsibility for our own speech. Be kind to
+   others. Do not insult or put down other participants.  We will not accept
+   harassment or other exclusionary behaviour, such as:
+
+    - Violent threats or language directed against another person.
+    - Sexist, racist, or otherwise discriminatory jokes and language.
+    - Posting sexually explicit or violent material.
+    - Posting (or threatening to post) other people's personally identifying information ("doxing").
+    - Sharing private content, such as emails sent privately or non-publicly,
+      or unlogged forums such as IRC channel history, without the sender's consent.
+    - Personal insults, especially those using racist or sexist terms.
+    - Unwelcome sexual attention.
+    - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
+    - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+    - Advocating for, or encouraging, any of the above behaviour.
+
+
+Diversity Statement
+-------------------
+
+The NetworkX project welcomes and encourages participation by everyone. We are
+committed to being a community that everyone enjoys being part of. Although
+we may not always be able to accommodate each individual's preferences, we try
+our best to treat everyone kindly.
+
+No matter how you identify yourself or how others perceive you: we welcome you.
+Though no list can hope to be comprehensive, we explicitly honour diversity in:
+age, culture, ethnicity, genotype, gender identity or expression, language,
+national origin, neurotype, phenotype, political beliefs, profession, race,
+religion, sexual orientation, socioeconomic status, subculture and technical
+ability.
+
+Though we welcome people fluent in all languages, NetworkX development is
+conducted in English.
+
+Standards for behaviour in the NetworkX community are detailed in the Code of
+Conduct above. Participants in our community should uphold these standards
+in all their interactions and help others to do so as well (see next section).
+
+
+Reporting Guidelines
+--------------------
+
+We know that it is painfully common for internet communication to start at or
+devolve into obvious and flagrant abuse.  We also recognize that sometimes
+people may have a bad day, or be unaware of some of the guidelines in this Code
+of Conduct. Please keep this in mind when deciding on how to respond to a
+breach of this Code.
+
+For clearly intentional breaches, report those to the NetworkX Steering Council
+(see below). For possibly unintentional breaches, you may reply to the person
+and point out this code of conduct (either in public or in private, whatever is
+most appropriate). If you would prefer not to do that, please feel free to
+report to the NetworkX Steering Council directly, or ask the Council for
+advice, in confidence.
+
+You can report issues to the
+`NetworkX Steering Council <https://github.com/orgs/networkx/teams/steering-council/members>`__,
+at networkx-conduct@groups.io.
+
+If your report involves any members of the Council, or if they feel they have
+a conflict of interest in handling it, then they will recuse themselves from
+considering your report. Alternatively, if for any reason you feel
+uncomfortable making a report to the Council, then you can also contact:
+
+- Senior `NumFOCUS staff <https://numfocus.org/code-of-conduct#persons-responsible>`__: conduct@numfocus.org.
+
+
+Incident reporting resolution & Code of Conduct enforcement
+-----------------------------------------------------------
+
+We will investigate and respond to all complaints. The NetworkX Steering Council
+will protect the identity of the reporter, and treat the content of
+complaints as confidential (unless the reporter agrees otherwise).
+
+In case of severe and obvious breaches, e.g., personal threat or violent, sexist
+or racist language, we will immediately disconnect the originator from NetworkX
+communication channels.
+
+In cases not involving clear severe and obvious breaches of this code of
+conduct, the process for acting on any received code of conduct violation
+report will be:
+
+1. acknowledge report is received
+2. reasonable discussion/feedback
+3. mediation (if feedback didn't help, and only if both reporter and reportee agree to this)
+4. enforcement via transparent decision by the NetworkX Steering Council
+
+The Council will respond to any report as soon as possible, and at most
+within 72 hours.
+
+
+Endnotes
+--------
+
+This document is adapted from:
+
+- `SciPy Code of Conduct <http://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,226 @@
+.. _contributor_guide:
+
+Contributor Guide
+=================
+
+.. note::
+   This document assumes some familiarity with contributing to open source
+   scientific Python projects using GitHub pull requests. If this does not
+   describe you, you may first want to see the `Contributing FAQ <https://github.com/networkx/networkx/blob/main/doc/developer/new_contributor_faq.rst>`_.
+
+.. _dev_workflow:
+
+Development Workflow
+--------------------
+
+1. If you are a first-time contributor:
+
+   * Go to `https://github.com/networkx/nx-guides
+     <https://github.com/networkx/nx-guides>`_ and click the
+     "fork" button to create your own copy of the project.
+
+   * Clone the project to your local computer::
+
+      git clone git@github.com:your-username/nx-guides.git
+
+   * Navigate to the folder networkx and add the upstream repository::
+
+      git remote add upstream git@github.com:networkx/nx-guides.git
+
+   * Now, you have remote repositories named:
+
+     - ``upstream``, which refers to the ``nx-guides`` repository
+     - ``origin``, which refers to your personal fork
+
+   * Next, you need to set up your build environment.
+     Here are instructions for two popular environment managers:
+
+     * ``venv`` (pip based)
+
+       ::
+
+         # Create a virtualenv named ``nx-guides-dev`` that lives in the directory of
+         # the same name
+         python -m venv nx-guides-dev
+         # Activate it
+         source nx-guides-dev/bin/activate
+         # Install main development and runtime dependencies of nx-guides
+         pip install -r requirements.txt
+
+     * ``conda`` (Anaconda or Miniconda)
+
+       ::
+
+         # Create a conda environment named ``nx-guides-dev``
+         conda create --name nx-guides-dev
+         # Activate it
+         conda activate nx-guides-dev
+         # Install main development and runtime dependencies of nx-guides
+         conda install -c conda-forge --file requirements.txt
+
+   * Finally, we recommend you use a pre-commit hook, which runs black when
+     you type ``git commit``::
+
+       pre-commit install
+
+2. Develop your contribution:
+
+   * Pull the latest changes from upstream::
+
+      git checkout main
+      git pull upstream main
+
+   * Create a branch for the feature you want to work on. Since the
+     branch name will appear in the merge message, use a sensible name
+     such as 'bugfix-for-issue-1480'::
+
+      git checkout -b bugfix-for-issue-1480
+
+   * Commit locally as you progress (``git add`` and ``git commit``)
+
+3. Submit your contribution:
+
+   * Push your changes back to your fork on GitHub::
+
+      git push origin bugfix-for-issue-1480
+
+   * Go to GitHub. The new branch will show up with a green Pull Request
+     button---click it.
+
+   * If you want, post on the `mailing list
+     <http://groups.google.com/group/networkx-discuss>`_ to explain your changes or
+     to ask for review.
+
+4. Review process:
+
+   * Every Pull Request (PR) update triggers a set of `continuous integration
+     <https://en.wikipedia.org/wiki/Continuous_integration>`_ services
+     that check that the code is up to standards and passes all our tests.
+     These checks must pass before your PR can be merged.  If one of the
+     checks fails, you can find out why by clicking on the "failed" icon (red
+     cross) and inspecting the build and test log.
+
+   * Reviewers (the other developers and interested community members) will
+     write inline and/or general comments on your PR to help
+     you improve its implementation, documentation, and style.  Every single
+     developer working on the project has their code reviewed, and we've come
+     to see it as friendly conversation from which we all learn and the
+     overall code quality benefits.  Therefore, please don't let the review
+     discourage you from contributing: its only aim is to improve the quality
+     of project, not to criticize (we are, after all, very grateful for the
+     time you're donating!).
+
+   * To update your PR, make your changes on your local repository
+     and commit. As soon as those changes are pushed up (to the same branch as
+     before) the PR will update automatically.
+
+   .. note::
+
+      If the PR closes an issue, make sure that GitHub knows to automatically
+      close the issue when the PR is merged.  For example, if the PR closes
+      issue number 1480, you could use the phrase "Fixes #1480" in the PR
+      description or commit message.
+
+
+Divergence from ``upstream main``
+---------------------------------
+
+If GitHub indicates that the branch of your Pull Request can no longer
+be merged automatically, merge the main branch into yours::
+
+   git fetch upstream main
+   git merge upstream/main
+
+If any conflicts occur, they need to be fixed before continuing.  See
+which files are in conflict using::
+
+   git status
+
+Which displays a message like::
+
+   Unmerged paths:
+     (use "git add <file>..." to mark resolution)
+
+     both modified:   file_with_conflict.txt
+
+Inside the conflicted file, you'll find sections like these::
+
+   <<<<<<< HEAD
+   The way the text looks in your branch
+   =======
+   The way the text looks in the main branch
+   >>>>>>> main
+
+Choose one version of the text that should be kept, and delete the
+rest::
+
+   The way the text looks in your branch
+
+Now, add the fixed file::
+
+
+   git add file_with_conflict.txt
+
+Once you've fixed all merge conflicts, do::
+
+   git commit
+
+.. note::
+
+   Advanced Git users may want to rebase instead of merge,
+   but we squash and merge PRs either way.
+
+
+Guidelines
+----------
+
+* All code should have tests.
+* All code should be documented, to the same
+  `standard <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
+  as NumPy and SciPy.
+* All changes are reviewed.  Ask on the
+  `mailing list <http://groups.google.com/group/networkx-discuss>`_ if
+  you get no response to your pull request.
+* New default dependencies should be easy to install on all
+  platforms, widely-used in the community, and have demonstrated potential for
+  wide-spread use in NetworkX.
+* Use the following import conventions::
+
+   import numpy as np
+   import scipy as sp
+   import matplotlib as mpl
+   import matplotlib.pyplot as plt
+   import pandas as pd
+   import networkx as nx
+
+  After importing `sp`` for ``scipy``::
+
+   import scipy as sp
+
+  use the following imports::
+
+   import scipy.linalg  # call as sp.linalg
+   import scipy.sparse  # call as sp.sparse
+   import scipy.sparse.linalg  # call as sp.sparse.linalg
+   import scipy.stats  # call as sp.stats
+   import scipy.optimize  # call as sp.optimize
+
+  For example, many libraries have a ``linalg`` subpackage: ``nx.linalg``,
+  ``np.linalg``, ``sp.linalg``, ``sp.sparse.linalg``. The above import
+  pattern makes the origin of any particular instance of ``linalg`` explicit.
+
+
+Bugs
+----
+
+Please `report bugs on GitHub <https://github.com/networkx/nx-guides/issues>`_.
+
+Policies
+--------
+
+All interactions with the project are subject to the `Code of Conduct <CODE_OF_CONDUCT.md>`_.
+
+We also follow these policies:
+
+* `Networkx Deprecations Policy <https://github.com/networkx/networkx/blob/main/doc/developer/deprecations.rst>`_
+* :doc:`Python version support <nep-0029-deprecation_policy>`

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -218,7 +218,7 @@ Please `report bugs on GitHub <https://github.com/networkx/nx-guides/issues>`_.
 Policies
 --------
 
-All interactions with the project are subject to the `Code of Conduct <CODE_OF_CONDUCT.md>`_.
+All interactions with the project are subject to the `Code of Conduct <CODE_OF_CONDUCT.rst>`_.
 
 We also follow these policies:
 


### PR DESCRIPTION
Fix for #53

- Added `CONTRIBUTING.rst` and `CODE_OF_CONDUCT.rst` similar to that of Networkx Repository
- Changed referenced links in to match `networkx/nx-guides`

Unlike `networkx`,`nx-guides` did not contain certain parts. So, removed the following parts of the file
- Testing, Release code in `Development Workflow`
- `Testing`, `Adding Test`, `Adding Examples` and `Image comparison`