### PR TITLE
Add temporary pin to fix lexer errors during build.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ numpy
 scipy
 matplotlib
 pandas
+# Temporary fix for lexer errors
+ipython!=8.7.0
 
 # For testing and site generation
 nbval


### PR DESCRIPTION
See ipython/ipython#13845.