### PR TITLE
CI: Add circleci redirector API token.

### DIFF
--- a/.github/workflows/circleci_artifact_redirector.yml
+++ b/.github/workflows/circleci_artifact_redirector.yml
@@ -8,5 +8,6 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_ARTIFACT_REDIRECTOR_TOKEN }}
           artifact-path: 0/site/_build/html/index.html
           circleci-jobs: build-docs


### PR DESCRIPTION
Fixes issues in CI with circleci doc artifact link. Followed the procedure described in larsoner/circleci-artifacts-redirector-action#40.