### PR TITLE
MAINT: Update nbqa hook and github workflow

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -37,15 +37,12 @@ jobs:
   
     - name: Install dependencies
       run: |
-        pip install pip==21.1.1
+        pip install -U pip
         pip install -r requirements.txt
 
     - name: Lint with precommit
       run: |
         pip install pre-commit
-        find content/ -name "*.md" -exec jupytext --to notebook {} \;
-        # pre-commit wants files to be staged
-        git add content/
         pre-commit run --all-files --show-diff-on-failure --color always
         
     - name: Test with nbval

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,10 @@
 repos:
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.3.1
+  rev: 1.7.0
   hooks:
-   - id: nbqa-black
    - id: nbqa-pyupgrade
-     args: [--py38-plus]
+     additional_dependencies: [jupytext]
+     args: [--py311-plus, --nbqa-shell]
+   - id: nbqa-black
+     additional_dependencies: [jupytext]
+     args: [--nbqa-shell]


### PR DESCRIPTION
We should be able to directly run the pre-commit on .md notebooks, no need for the weird conversion.