### PR TITLE
Update runtime.txt to Python 3.9 and fix link to myst-nb docs

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8
+python-3.9

--- a/site/index.md
+++ b/site/index.md
@@ -26,7 +26,7 @@ You can follow along yourself:
  2. *locally*, by cloning the repository (see the octocat icon above) and
     running `jupyter notebook`.
 
-[myst-nb]: https://myst-nb.readthedocs.io/en/latest/use/markdown.html
+[myst-nb]: https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html
 
 ## Contents
 


### PR DESCRIPTION
I’m not sure whether more is needed to get binder working, but right now binder fails because the required version of Python for the NetworkX library is 3.9 and the binder is using 3.8.