### PR TITLE
convert to ipynb before pre-commit

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Lint with precommit
       run: |
         pip install pre-commit
+        find content/ -name "*.md" -exec jupytext --to notebook {} \;
+        # pre-commit wants files to be staged
+        find content/ -name "*.ipynb" -exec git add {} \;
         pre-commit run --all-files --show-diff-on-failure --color always
         
     - name: Test with nbval


### PR DESCRIPTION
Make pre-commit section of tests convert to ipynb so that nbqa-black and nbqa-pyupgrade can run.