### PR TITLE
Update geometric tutorial for networkx/networkx#7565.

### DIFF
--- a/content/generators/geometric.md
+++ b/content/generators/geometric.md
@@ -198,7 +198,7 @@ import json
 
 # load json-ed networkx datafile
 with open("data/tesla_network.json") as infile:
-    G = nx.json_graph.node_link_graph(json.load(infile))
+    G = nx.json_graph.node_link_graph(json.load(infile), edges="links")
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
networkx/networkx#7565 changed the API for `node_link_*` functions to update the default `edges=` value from `"links"` to `"edges"`.

FWIW this failure is an indication that we may actually be breaking things in the wild!