### PR TITLE
Use recommended calling convention for node_link_graph.

### DIFF
--- a/content/generators/geometric.md
+++ b/content/generators/geometric.md
@@ -198,7 +198,7 @@ import json
 
 # load json-ed networkx datafile
 with open("data/tesla_network.json") as infile:
-    G = nx.json_graph.node_link_graph(json.load(infile), edges="links")
+    G = nx.node_link_graph(json.load(infile), edges="links")
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Minor follow-up to #135 - update the calling convention for `node_link_graph` to highlight the recommended access pattern (i.e. remove the sub-package).