### PR TITLE
Re-add pygraphviz as a dependency.

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -42,7 +42,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip
-        pip install -r requirements.txt
 
         if [ "$RUNNER_OS" == "macOS" ]; then
           pip install --config-settings="--global-option=build_ext" \
@@ -51,7 +50,11 @@ jobs:
                       pygraphviz
         elif [ "$RUNNER_OS" == "Linux" ]; then
           pip install pygraphviz
+
         fi
+
+        pip install -r requirements.txt
+        pip list
 
     - name: Lint with precommit
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 # nx-guides is tested on the development branch of NetworkX
 git+https://github.com/networkx/networkx@main
 
-# Scientific Python (see networkx/requirements/default.txt)
+# Dependencies for running the tutorials
 numpy
 scipy
 matplotlib
 pandas
 ipython!=8.7.0
+pygraphviz
 
 # For testing and site generation
 nbval


### PR DESCRIPTION
#134 removed pygraphviz from the requirements - I think the motivation was to get CI working, but pygraphviz *is* a dependency; i.e. for building locally (and why the circleCI is consistently failing).

I propose to add it back - if this breaks the other CI then I think we can find another workaround!