### PR TITLE
Bump minimum Python version to 3.11 and add 3.13.

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [Ubuntu-22.04, macOS-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Failures on the scheduled jobs due to the development branch of networkx no longer supporting 3.10 (so things are working as intended!)