### PR TITLE
Propsal: make main toctree hidden.

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -28,11 +28,10 @@ You can follow along yourself:
 
 [myst-nb]: https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html
 
-## Contents
-
 ```{toctree}
 ---
 maxdepth: 1
+hidden: true
 ---
 
 content/algorithms/index


### PR DESCRIPTION
Minor style proposal: the main toctree in `index.md` is primarily used to populate the side navbar. I propose to add `hidden: true` to the options to prevent the toctree from rendering at the bottom of the landing page, which IMO is both redundant and unsightly!